### PR TITLE
Replace Carthage with CocoaPods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-Carthage/Checkouts
-Carthage/Build
+# Bundler
+vendor
+.bundle
+
+# CocoaPods
+Pods/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "cocoapods"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,72 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.5)
+    activesupport (4.2.10)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (1.0.2)
+    cocoapods (1.3.1)
+      activesupport (>= 4.0.2, < 5)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.3.1)
+      cocoapods-deintegrate (>= 1.0.1, < 2.0)
+      cocoapods-downloader (>= 1.1.3, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.2.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (~> 2.0.1)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.5.7)
+      nap (~> 1.0)
+      ruby-macho (~> 1.1)
+      xcodeproj (>= 1.5.1, < 2.0)
+    cocoapods-core (1.3.1)
+      activesupport (>= 4.0.2, < 6)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.1)
+    cocoapods-downloader (1.1.3)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.0.0)
+    cocoapods-trunk (1.3.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.1.0)
+    colored2 (3.1.2)
+    escape (0.0.4)
+    fourflusher (2.0.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.0.3)
+    i18n (0.8.6)
+    minitest (5.10.3)
+    molinillo (0.5.7)
+    nanaimo (0.2.3)
+    nap (1.1.0)
+    netrc (0.11.0)
+    ruby-macho (1.1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    xcodeproj (1.5.2)
+      CFPropertyList (~> 2.3.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.2.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods
+
+BUNDLED WITH
+   1.14.6

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,20 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'bit-flyer-chart-mvvm' do
+  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for bit-flyer-chart-mvvm
+
+  target 'bit-flyer-chart-mvvmTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+  target 'bit-flyer-chart-mvvmUITests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+end


### PR DESCRIPTION
使うライブラリ管理ツールを `Carthage` から `CocoaPods` に変更しました。

元々今まで使っていたのがずっと `CocoaPods` だったので今回は勉強がてら `Carthage` を使ってみようと思っていました。

しかし今回使う予定だった[R.swift](https://github.com/mac-cain13/R.swift)や[RxSwift](https://github.com/ReactiveX/RxSwift)をプロジェクトへ導入する際のコストが明らかに `CocoaPods` のほうが楽だったため、あまりそこで手間取りたくないという理由で（あと試して `Carthage` はだいたい使い方分かった）、今回はCocoaPodsを使うことにします。

CocoaPodsもCarthage同様、勉強用のアプリという理由で `Pods/` はignoreしておきます。